### PR TITLE
WIP: Remove studio forks

### DIFF
--- a/cms/templates/asset_index.html
+++ b/cms/templates/asset_index.html
@@ -54,29 +54,7 @@
 <div class="wrapper-content wrapper">
     <section class="content">
         <article class="content-primary" role="main">
-            % if settings.FEATURES.get('CONTENT_VISIBILITY_NOTICE',''):
-            <div id="content-visibility-notice">
-                <div class="wrapper wrapper-alert wrapper-alert-warning is-shown">
-                    <div class="alert warning ">
-                        <i class="feedback-symbol fa fa-warning"></i>
-                        <div class="copy">
-                            <h2 class="title" id="notice-title">Content Visibility Notice</h2>
-                            <p class="message">
-                              ${_("Materials uploaded here are viewable by the general public in addition "
-                              "to your registered Stanford students. Such publicly-viewable content is subject "
-                              "to copyright exemptions more restrictive than material viewable only by registered "
-                              "Stanford students. Therefore, before uploading any content that has not been "
-                              "created by you or content to which neither you nor Stanford owns all of the "
-                              "rights, you must obtain the permissions (releases, waivers, licenses, etc.) "
-                              "necessary to distribute such materials to the public through the Internet. "
-                              "If you have any questions, please send an email to "
-                              "{copyright_email}").format(copyright_email=settings.COPYRIGHT_EMAIL)}
-                            </p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            % endif
+            <%static:optional_include_mako file="asset_index_content_header.html" />
             <div class="wrapper-assets" />
             <div class="ui-loading">
                 <p><span class="spin"><span class="icon fa fa-refresh" aria-hidden="true"></span></span> <span class="copy">${_("Loading")}</span></p>

--- a/cms/templates/asset_index_content_header.html
+++ b/cms/templates/asset_index_content_header.html
@@ -1,0 +1,20 @@
+## Update text for upstream PR
+<div class="wrapper wrapper-alert wrapper-alert-warning is-shown">
+    <div class="alert warning ">
+        <i class="feedback-symbol fa fa-warning"></i>
+        <div class="copy">
+            <h2 class="title">Content Visibility Notice</h2>
+            <p class="message">
+              ${_("Materials uploaded here are viewable by the general public in addition "
+              "to your registered Stanford students. Such publicly-viewable content is subject "
+              "to copyright exemptions more restrictive than material viewable only by registered "
+              "Stanford students. Therefore, before uploading any content that has not been "
+              "created by you or content to which neither you nor Stanford owns all of the "
+              "rights, you must obtain the permissions (releases, waivers, licenses, etc.) "
+              "necessary to distribute such materials to the public through the Internet. "
+              "If you have any questions, please send an email to "
+              "{copyright_email}").format(copyright_email=settings.COPYRIGHT_EMAIL)}
+            </p>
+        </div>
+    </div>
+</div>

--- a/cms/templates/base.html
+++ b/cms/templates/base.html
@@ -62,12 +62,7 @@ from openedx.core.djangolib.js_utils import (
     </script>
     <script type="text/javascript" src="${static.url("common/js/vendor/require.js")}"></script>
     <script type="text/javascript" src="${static.url("cms/js/require-config.js")}"></script>
-
-    <script type="text/javascript">
-        // TODO: Remove this!
-        // This is a stop-gap "fix" to silence a Studio exception.
-        function setupFullScreenImage(){}
-    </script>
+    <%include file="stanford-hack-full-screen-image.html" />
 
     <!-- view -->
     <div class="wrapper wrapper-view" dir="${static.dir_rtl()}">

--- a/cms/templates/course_info.html
+++ b/cms/templates/course_info.html
@@ -7,7 +7,6 @@ from django.utils.translation import ugettext as _
 from openedx.core.djangolib.js_utils import (
     dump_js_escaped_json, js_escaped_string
 )
-from openedx.core.djangolib.markup import HTML, Text
 %>
 
 ## TODO decode course # from context_course into title.
@@ -57,10 +56,6 @@ from openedx.core.djangolib.markup import HTML, Text
     <section class="content">
       <div class="introduction">
         <p class="copy">${_('Use course updates to notify students of important dates or exams, highlight particular discussions in the forums, announce schedule changes, and respond to student questions. You add or edit updates in HTML.')}</p>
-        <p><strong>${Text(_('Updates support {link_start}keyword substitution{link_end}.')).format(
-          link_start=HTML('<a rel="modal" href="#keyword-sub-modal">'),
-          link_end=HTML('</a>'))}</strong>
-        </p>
       </div>
     </section>
   </div>

--- a/cms/templates/course_info_introduction_post.html
+++ b/cms/templates/course_info_introduction_post.html
@@ -1,0 +1,10 @@
+<%!
+from openedx.core.djangolib.markup import HTML, Text
+%>
+
+<p>
+    <strong>${Text(_('Updates support {link_start}keyword substitution{link_end}.')).format(
+        link_start=HTML('<a rel="modal" href="#keyword-sub-modal">'),
+        link_end=HTML('</a>'),
+    )}</strong>
+</p>

--- a/cms/templates/course_outline.html
+++ b/cms/templates/course_outline.html
@@ -26,11 +26,12 @@ from openedx.core.djangolib.markup import HTML, Text
 
 <%block name="header_extras">
 <link rel="stylesheet" type="text/css" href="${static.url('js/vendor/timepicker/jquery.timepicker.css')}" />
-% for template_name in ['course-outline', 'xblock-string-field-editor', 'basic-modal', 'modal-button', 'course-outline-modal', 'due-date-editor', 'release-date-editor', 'grading-editor', 'publish-editor', 'staff-lock-editor', 'content-visibility-editor', 'verification-access-editor', 'timed-examination-preference-editor', 'access-editor', 'settings-modal-tabs', 'show-correctness-editor']:
+% for template_name in ['course-outline', 'xblock-string-field-editor', 'basic-modal', 'modal-button', 'course-outline-modal', 'due-date-editor', 'release-date-editor', 'grading-editor', 'publish-editor', 'staff-lock-editor', 'content-visibility-editor', 'verification-access-editor', 'timed-examination-preference-editor', 'access-editor', 'settings-modal-tabs']:
 <script type="text/template" id="${template_name}-tpl">
     <%static:include path="js/${template_name}.underscore" />
 </script>
 % endfor
+<%static:optional_include_mako file="course_outline_header_extras_post.html" />
 </%block>
 
 <%block name="page_alert">

--- a/cms/templates/course_outline_header_extras_post.html
+++ b/cms/templates/course_outline_header_extras_post.html
@@ -1,0 +1,4 @@
+% for template_name in ['show-correctness-editor',]:
+<script type="text/template" id="${template_name}-tpl">
+    <%static:include path="js/${template_name}.underscore" />
+</script>

--- a/cms/templates/index.html
+++ b/cms/templates/index.html
@@ -298,6 +298,7 @@ from openedx.core.djangolib.markup import HTML, Text
       % if libraries_enabled or is_programs_enabled:
       <ul id="course-index-tabs">
         <li class="courses-tab active">
+          ## PR upstream without feature flag
           % if split_studio_home:
             <a href="/home">${_("Courses")}</a>
           % else:

--- a/cms/templates/settings.html
+++ b/cms/templates/settings.html
@@ -343,6 +343,7 @@ CMS.URL.UPLOAD_ASSET = '${upload_asset_url | n, js_escaped_string}'
                     )}</span>
                 </li>
                 
+                ## PR this feature upstream
                 <li class="field text" id="field-course-about-sidebar-html">
                     <label for="course-about-sidebar-html">${_("Course About Sidebar HTML")}</label>
                     <textarea class="tinymce text-editor" id="course-about-sidebar-html"></textarea>

--- a/cms/templates/stanford-hack-full-screen-image.html
+++ b/cms/templates/stanford-hack-full-screen-image.html
@@ -1,0 +1,5 @@
+<script type="text/javascript">
+    // TODO: Remove this!
+    // This is a stop-gap "fix" to silence a Studio exception.
+    function setupFullScreenImage(){}
+</script>

--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -225,22 +225,7 @@
         <ol>
           <li class="nav-item nav-account-help">
             <h3 class="title"><span class="label" title="${_('Contextual Online Help')}" target="_blank">${_("Help")}</span></h3>
-
-            <div class="wrapper wrapper-nav-sub">
-              <div class="nav-sub">
-                <ul>
-                  <li class="nav-item nav-help-documentation">
-                    <a href="https://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/index.html">${_("Studio Documentation")}</a>
-                  </li>
-                  <li class="nav-item nav-help-helpcenter">
-                    <a href="https://stanfordonline.zendesk.com/hc" target="_blank" rel="external">${_("Help Center")}</a>
-                  </li>
-                  <li class="nav-item nav-help-feedback">
-                    <a href="mailto:courseops@stanfordonline.zendesk.com" title="${_("Share your feedback with us.")}">${_("Contact Us")}</a>
-                  </li>
-                </ul>
-              </div>
-            </div>
+            <%include file="header_nav_help_post.html" />
           </li>
           <li class="nav-item nav-account-user">
             <%include file="user_dropdown.html" args="online_help_token=online_help_token" />

--- a/cms/templates/widgets/header_nav_help_post.html
+++ b/cms/templates/widgets/header_nav_help_post.html
@@ -1,0 +1,15 @@
+<div class="wrapper wrapper-nav-sub">
+    <div class="nav-sub">
+        <ul>
+            <li class="nav-item nav-help-documentation">
+                <a href="https://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/index.html">${_("Studio Documentation")}</a>
+            </li>
+            <li class="nav-item nav-help-helpcenter">
+                <a href="https://stanfordonline.zendesk.com/hc" target="_blank" rel="external">${_("Help Center")}</a>
+            </li>
+            <li class="nav-item nav-help-feedback">
+                <a href="mailto:courseops@stanfordonline.zendesk.com" title="${_("Share your feedback with us.")}">${_("Contact Us")}</a>
+            </li>
+        </ul>
+    </div>
+</div>

--- a/cms/templates/widgets/sock.html
+++ b/cms/templates/widgets/sock.html
@@ -22,6 +22,7 @@ from django.core.urlresolvers import reverse
 
         partner_email = settings.PARTNER_SUPPORT_EMAIL
 
+        ## List.append or reformat with trailing comma or setting list of dicts?
         links = [{
             'href': 'http://docs.edx.org',
             'sr_mouseover_text': _('Access documentation on http://docs.edx.org'),


### PR DESCRIPTION
- [x] Moves Asset Header to separate file
- [x] Moves stanford FullScreenImage hack to file
- [x] Moves course info keyword subs to file
- [x] Move extra underscore includes to file
- [ ] TODO: PR split studio home upstream
- [x] TODO: PR course about sidebar HTML upstream
- [x] Moves header subnav to file
- [x] TODO: PR upstream reformatting sock list of dicts